### PR TITLE
docs: add release-readiness baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Agent Instructions for @vllnt/logger
+
+This repository contains the public `@vllnt/logger` npm package.
+
+## Scope
+
+- Keep changes focused on structured logging utilities, tests, docs, and release-readiness files.
+- Do not publish to npm, create tags, bump versions, merge PRs, or announce releases unless explicitly instructed by a human maintainer.
+- Do not add private VLLNT operational details, credentials, customer data, or internal roadmap content to public files.
+
+## Commands
+
+Use pnpm:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run lint
+pnpm run check-types
+pnpm run build
+pnpm run test
+```
+
+## Package constraints
+
+- Preserve zero runtime dependencies.
+- Preserve `sideEffects: false` unless a maintainer approves a change.
+- Keep Convex-safe exports free of `process.env` and other Node-only assumptions.
+- Update `README.md`, `CHANGELOG.md`, `llms.txt`, and `llms-full.txt` when changing public API or package positioning.
+
+## Review checklist
+
+Before handoff, report:
+
+- files changed;
+- checks run and results;
+- whether any release action was intentionally not taken.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses semantic versioning for published npm releases.
+
+## [Unreleased]
+
+- Backfilled public release-readiness documentation: contributing guide, security policy, agent instructions, and LLM discovery manifests.
+
+## [0.1.2] - 2026-03-10
+
+### Changed
+
+- Published the `0.1.2` maintenance release for `@vllnt/logger`.
+
+## [0.1.1] - 2026-03-10
+
+### Changed
+
+- Published the `0.1.1` maintenance release for `@vllnt/logger`.
+
+## [0.1.0] - 2026-03-09
+
+### Added
+
+- Initial public release of the structured logger package.
+- Added core logger APIs, backend preset, Convex-safe logger, PostHog output adapter, and in-memory testing output.
+
+[Unreleased]: https://github.com/vllnt/logger/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/vllnt/logger/releases/tag/v0.1.2
+[0.1.1]: https://github.com/vllnt/logger/releases/tag/v0.1.1
+[0.1.0]: https://github.com/vllnt/logger/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to @vllnt/logger
+
+Thank you for helping improve `@vllnt/logger`.
+
+This package is intentionally small: zero runtime dependencies, predictable structured JSON output, and runtime-safe subpath exports for Node.js, Convex, PostHog, and tests. Please keep changes focused on that contract.
+
+## Development
+
+Requirements:
+
+- Node.js 22 or newer
+- pnpm 10.28.2 or compatible
+
+Setup:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Common checks:
+
+```bash
+pnpm run lint
+pnpm run check-types
+pnpm run build
+pnpm run test
+```
+
+## Pull requests
+
+Before opening a pull request:
+
+1. Create a branch from `main`.
+2. Keep the diff scoped to one concern.
+3. Add or update tests for behavior changes.
+4. Run the common checks above.
+5. Document public API changes in `README.md` and `CHANGELOG.md`.
+
+## Release notes
+
+Do not bump versions, create tags, or publish from a documentation or feature PR unless the maintainer explicitly asks for a release. Public release entries belong in `CHANGELOG.md`.
+
+## Design constraints
+
+- Keep the package dependency-free at runtime.
+- Preserve crash-safe serialization.
+- Preserve reserved field protection for `event`, `level`, and `timestamp`.
+- Keep subpath exports stable unless a breaking change is intentional and documented.
+- Avoid runtime-specific globals in Convex-safe exports.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported versions
+
+Security updates target the latest published `@vllnt/logger` release on npm.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately through GitHub's security reporting flow for this repository if it is available.
+
+If private reporting is unavailable, contact the maintainers through the `vllnt/logger` GitHub repository without including exploit details in a public issue. Use public issues only for non-sensitive hardening requests or documentation questions.
+
+## Scope
+
+This package provides structured logging utilities. Security-sensitive areas include:
+
+- crash-safe serialization of arbitrary log data;
+- prevention of user data overwriting reserved log fields;
+- runtime-safe behavior across Node.js, Convex, browser, and edge environments;
+- avoiding accidental introduction of runtime dependencies or secret-handling side effects.
+
+## Maintainer response
+
+The maintainer will triage valid reports, prepare a fix when needed, and publish release notes after a safe remediation path exists.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,98 @@
+# @vllnt/logger full reference
+
+`@vllnt/logger` provides structured JSON logging for the `@vllnt` ecosystem. It is dependency-free at runtime, tree-shakeable, and designed to run in Node.js, Convex, browser, and edge runtimes.
+
+## Public package facts
+
+- Package name: `@vllnt/logger`
+- Repository: https://github.com/vllnt/logger
+- License: MIT
+- Current documented release: `0.1.2`
+- Runtime dependencies: none
+- Package manager: pnpm
+
+## Installation
+
+```bash
+pnpm add @vllnt/logger
+```
+
+## Quick start
+
+```ts
+import { createBackendLogger } from "@vllnt/logger";
+
+const logger = createBackendLogger("auth");
+
+logger.info("login", { userId: "123" });
+logger.warn("rate-limited", { ip: "1.2.3.4" });
+```
+
+Set `LOG_LEVEL` to `debug`, `info`, `warn`, or `error` to control backend verbosity. The default is `warn`.
+
+## Subpath exports
+
+| Import | Use case |
+| --- | --- |
+| `@vllnt/logger` | Core API and Node.js backend preset |
+| `@vllnt/logger/convex` | Convex-safe logger with no `process.env` access |
+| `@vllnt/logger/posthog` | PostHog output adapter |
+| `@vllnt/logger/testing` | In-memory test output for assertions |
+
+## API summary
+
+### `createBackendLogger(scope)`
+
+Creates an extended logger preconfigured for Node.js backends. It reads `LOG_LEVEL` lazily from `process.env` on each log call.
+
+### `createLogger(scope, config)`
+
+Creates a core logger with caller-provided log-level and output strategies.
+
+### `createExtendedLogger(scope, config)`
+
+Creates a logger with `withTiming` and `withTimingSync` helpers. Timing helpers emit `.start`, `.complete`, and `.error` events with duration metadata.
+
+### `composeOutputs(...outputs)`
+
+Fans out log entries to multiple outputs. Outputs are isolated so one output failure does not prevent later outputs from receiving the entry.
+
+### `createConvexLogger(scope, level?)`
+
+Creates a Convex-safe extended logger. Use this in Convex queries, mutations, and actions.
+
+### `createPostHogOutput(capture)`
+
+Wraps a PostHog-compatible capture function as a logger output and swallows adapter errors.
+
+### `createTestOutput()`
+
+Creates an in-memory output for tests. Use the collected entries for assertions.
+
+## Types
+
+- `LogLevel`: `"debug" | "info" | "warn" | "error"`
+- `LogData`: `Record<string, unknown>`
+- `LogEntry`: structured event, level, timestamp, and user data
+- `LogOutput`: synchronous output function
+- `Logger`: debug/info/warn/error methods
+- `ExtendedLogger`: logger plus timing helpers
+- `LoggerConfig`: log-level function and output function
+
+## Design decisions
+
+- Scoped events are prefixed with the logger scope.
+- User data cannot overwrite `event`, `level`, or `timestamp`.
+- Serialization handles BigInt, circular references, and throwing `toJSON` implementations.
+- Outputs are synchronous by design.
+- Log level evaluation is lazy.
+- The core module has no module-level side effects.
+
+## Contributing and security
+
+- Contribution guide: `CONTRIBUTING.md`
+- Security policy: `SECURITY.md`
+- Changelog: `CHANGELOG.md`
+- Agent instructions: `AGENTS.md`
+
+Assistants should avoid suggesting that secrets, tokens, or sensitive personal data be logged. For Convex examples, prefer the Convex subpath export.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,37 @@
+# @vllnt/logger
+
+`@vllnt/logger` is a small structured logging package for the `@vllnt` ecosystem. It emits predictable JSON log entries, has zero runtime dependencies, and supports Node.js, Convex, browser, edge, PostHog, and test environments through stable exports.
+
+## Package
+
+- npm: `@vllnt/logger`
+- Repository: https://github.com/vllnt/logger
+- License: MIT
+- Runtime dependencies: none
+
+## Install
+
+```bash
+pnpm add @vllnt/logger
+```
+
+## Main exports
+
+- `@vllnt/logger`: core API and Node.js backend preset
+- `@vllnt/logger/convex`: Convex-safe logger without `process.env` access
+- `@vllnt/logger/posthog`: PostHog output adapter
+- `@vllnt/logger/testing`: in-memory output for test assertions
+
+## Key APIs
+
+- `createBackendLogger(scope)`
+- `createLogger(scope, config)`
+- `createExtendedLogger(scope, config)`
+- `composeOutputs(...outputs)`
+- `createConvexLogger(scope, level?)`
+- `createPostHogOutput(capture)`
+- `createTestOutput()`
+
+## Usage notes for assistants
+
+Prefer scoped event names and structured data. Do not recommend adding sensitive values to log data. For Convex code, use `@vllnt/logger/convex` rather than the Node backend preset.


### PR DESCRIPTION
## Summary
- Add minimal release-readiness docs for `@vllnt/logger`: `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `AGENTS.md`, `llms.txt`, and `llms-full.txt`
- Document the current public package API, support/security expectations, and no-release agent guardrails
- No version bump, tag, publish, merge, or announcement action taken

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run check-types`
- `pnpm run build`
- `pnpm run test` (33 tests passed)
- `git diff --check HEAD~1..HEAD`

## Review gate
```json
{"branch":"vllnt-oss","tenant":"releases","aor_fit":true,"context_read":true,"evidence_attached":true,"opsec_checked":true,"safe_for_next_step":true,"blocking_findings":[]}
```
